### PR TITLE
#6 Added possibility to provide custom guzzle options

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -7,10 +7,12 @@ use Psr\Cache\CacheItemPoolInterface as Cache;
 
 class ClientBuilder
 {
-    public static function build(string $endpoint)
+    public static function build(string $endpoint, array $guzzleOptions = []): Client
     {
+        $guzzleOptions = array_merge(['base_uri' => $endpoint], $guzzleOptions);
+
         return new \Softonic\GraphQL\Client(
-            new \GuzzleHttp\Client(['base_uri' => $endpoint]),
+            new \GuzzleHttp\Client($guzzleOptions),
             new \Softonic\GraphQL\ResponseBuilder()
         );
     }
@@ -19,11 +21,11 @@ class ClientBuilder
         string $endpoint,
         OAuth2Provider $oauthProvider,
         array $tokenOptions,
-        Cache $cache
+        Cache $cache,
+        array $guzzleOptions = []
     ): Client {
-        $guzzleOptions = [
-            'base_uri' => $endpoint,
-        ];
+        $guzzleOptions = array_merge(['base_uri' => $endpoint], $guzzleOptions);
+
 
         return new \Softonic\GraphQL\Client(
             \Softonic\OAuth2\Guzzle\Middleware\ClientBuilder::build(

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Softonic\GraphQL\Test;
 
+use GuzzleHttp\Cookie\CookieJar;
 use PHPUnit\Framework\TestCase;
 use Softonic\GraphQL\ClientBuilder;
 
@@ -10,6 +11,16 @@ class ClientBuilderTest extends TestCase
     public function testBuild()
     {
         $client = ClientBuilder::build('http://foo.bar/qux');
+        $this->assertInstanceOf(\Softonic\GraphQL\Client::class, $client);
+    }
+
+    public function testBuildWithGuzzleOptions()
+    {
+        $guzzleOptions = [
+            'cookies' => new CookieJar(),
+        ];
+
+        $client = ClientBuilder::build('http://foo.bar/qux', $guzzleOptions);
         $this->assertInstanceOf(\Softonic\GraphQL\Client::class, $client);
     }
 
@@ -27,6 +38,29 @@ class ClientBuilderTest extends TestCase
             $mockProvider,
             $mockTokenOptions,
             $mockCache
+        );
+        $this->assertInstanceOf(\Softonic\GraphQL\Client::class, $client);
+    }
+
+    public function testBuildWithOAuth2ProviderAndGuzzleOptions()
+    {
+        $mockCache = $this->createMock(\Psr\Cache\CacheItemPoolInterface::class);
+        $mockProvider = $this->createMock(\League\OAuth2\Client\Provider\AbstractProvider::class);
+        $mockTokenOptions = [
+            'grant_type' => 'client_credentials',
+            'scope' => 'myscope',
+        ];
+
+        $guzzleOptions = [
+            'cookies' => new CookieJar(),
+        ];
+
+        $client = ClientBuilder::buildWithOAuth2Provider(
+            'http://foo.bar/qux',
+            $mockProvider,
+            $mockTokenOptions,
+            $mockCache,
+            $guzzleOptions
         );
         $this->assertInstanceOf(\Softonic\GraphQL\Client::class, $client);
     }


### PR DESCRIPTION
This PR adds the possibility to provide custom guzzle options when using `ClientBuilder`.

This is essential if you have custom authorization methods, need to set cookies, headers, etc.