### PR TITLE
Improve exception message when GraphQL query or JSON  decoding fails.

### DIFF
--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -20,7 +20,13 @@ class ResponseBuilder
         $decodedResponse = $this->getJsonDecodedResponse($body);
         
         if (!array_key_exists('data', $decodedResponse)) {
-            throw new \UnexpectedValueException('Invalid GraphQL JSON response.');
+            $message = 'Invalid GraphQL JSON response.';
+            if (array_key_exists('errors', $decodedResponse)
+                && is_array($decodedResponse['errors'])
+                && array_key_exists('message', $decodedResponse['errors'][0])) {
+                $message .= ' ' . stripslashes($decodedResponse['errors'][0]['message']);
+            }
+            throw new \UnexpectedValueException($message);
         }
 
         return [
@@ -35,7 +41,11 @@ class ResponseBuilder
 
         $error = json_last_error();
         if (JSON_ERROR_NONE !== $error) {
-            throw new \UnexpectedValueException('Invalid JSON response.');
+            $message = 'Invalid JSON response.';
+            if (json_last_error_msg()) {
+                $message .= ' ' . json_last_error_msg();
+            }
+            throw new \UnexpectedValueException($message);
         }
         return $response;
     }


### PR DESCRIPTION
When discovering reasons why a GQL mutation (for example) would fail, I was missing details from the remote endpoint which gave some context to what was happening and why.

This PR adds support for elaborating on the message that is returned when an `UnexpectedValueException` is thrown.