### PR TITLE
Update travis to check new PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ sudo: false
 
 matrix:
   include:
-    - php: 7.0
-      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false
     - php: 7.1
+      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=true
+    - php: 7.2
+      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=true
+    - php: 7.3
       env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=true
     - php: master
       env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false


### PR DESCRIPTION
Now the versions tested are >= 7.1. 7.0 is not maintained anymore. That does not mean that the library doesn't work with that version, but we won't check it, so in any time it could crash.

More information: https://www.php.net/supported-versions.php