### PR TITLE
Added Guzzle Options For Catch Http Errors

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -23,6 +23,7 @@ class Client
     public function query(string $query, array $variables = null): Response
     {
         $options = [
+            'http_errors' => false,
             'json' => [
                 'query' => $query,
             ],


### PR DESCRIPTION
When graphql result http error 400 or 500, function responses `hasErrors()` not working.

I'm added Guzzle Options to handle this.

## Code to Produce Output
```
if($req->hasErrors())
{
    return 'error';
}
```

## Errors in Laravel (Before)
![Screenshot from 2020-01-30 11-38-37](https://user-images.githubusercontent.com/31454084/73420519-5ecd1080-4355-11ea-9816-e6f77d64063a.png)

## Errors in Laravel (After)
![Screenshot from 2020-01-30 11-39-00](https://user-images.githubusercontent.com/31454084/73420604-a2c01580-4355-11ea-8d43-24b67ec5c4cc.png)
