### PR TITLE
Add generate mutation tests command and instrospection

### DIFF
--- a/bin/graphql-client
+++ b/bin/graphql-client
@@ -1,0 +1,15 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Softonic\GraphQL\Console\Mutation\GenerateConfig;
+use Softonic\GraphQL\Console\Mutation\GetIntrospection;
+use Symfony\Component\Console\Application;
+
+$application = new Application();
+
+$application->add(new GenerateConfig());
+$application->add(new GetIntrospection());
+
+$application->run();

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,13 @@
 {
   "name": "softonic/graphql-client",
   "type": "library",
-  "description" : "Softonic GraphQL client",
-  "keywords": ["softonic", "oauth2", "graphql", "client"],
+  "description": "Softonic GraphQL client",
+  "keywords": [
+    "softonic",
+    "oauth2",
+    "graphql",
+    "client"
+  ],
   "license": "Apache-2.0",
   "homepage": "https://github.com/softonic/graphql-client",
   "support": {
@@ -12,7 +17,8 @@
     "php": ">=7.1",
     "guzzlehttp/guzzle": "^6.3",
     "softonic/guzzle-oauth2-middleware": "^1.1",
-    "ext-json": "*"
+    "ext-json": "*",
+    "symfony/console": "^4.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",
@@ -28,6 +34,9 @@
       "Softonic\\GraphQL\\Test\\": "tests/"
     }
   },
+  "bin": [
+    "bin/graphql-client-generator"
+  ],
   "scripts": {
     "test": "phpunit --coverage-text; php-cs-fixer fix -v --diff --dry-run --allow-risky=yes;",
     "phpunit": "phpunit --coverage-text",

--- a/src/Console/Mutation/GenerateConfig.php
+++ b/src/Console/Mutation/GenerateConfig.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Softonic\GraphQL\Console\Mutation;
+
+use Softonic\GraphQL\Config\MutationTypeConfig;
+use Softonic\GraphQL\Mutation\Collection;
+use Softonic\GraphQL\Mutation\Item;
+use stdClass;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GenerateConfig extends Command
+{
+    const SCALAR = 'SCALAR';
+
+    const INPUT_OBJECT = 'INPUT_OBJECT';
+
+    const LIST = 'LIST';
+
+    protected static $defaultName = 'mutation:generate-config';
+
+    protected function configure()
+    {
+        $this->setDescription('Creates a mutation config.')
+            ->setHelp('This command allows you to create a mutation config based in the result of a ' .
+                'introspection query for a specific mutation.');
+
+        $this
+            ->addArgument(
+                'instrospection-result',
+                InputArgument::REQUIRED,
+                'Json file with the introspection query result'
+            )
+            ->addArgument(
+                'mutation',
+                InputArgument::REQUIRED,
+                'Mutation name to extract to the configuration'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (!$this->checkArguments($input, $output)) {
+            return 1;
+        }
+
+        $jsonSchema = file_get_contents($input->getArgument('instrospection-result'));
+        $mutation   = $input->getArgument('mutation');
+
+        $mutationConfig = $this->generateConfig(json_decode($jsonSchema), $mutation);
+
+        $output->writeln(var_export($mutationConfig, true));
+
+        return 0;
+    }
+
+    private function checkArguments(InputInterface $input, OutputInterface $output)
+    {
+        $jsonPath = $input->getArgument('instrospection-result');
+
+        if (!file_exists($jsonPath)) {
+            $output->writeln("The file '{$jsonPath}' does not exist");
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function generateConfig(StdClass $jsonSchema, string $mutation)
+    {
+        foreach ($jsonSchema->data->__schema->types as $type) {
+            if ($type->name === 'Mutation' && $type->fields[0]->name === $mutation) {
+                $initialMutationField = $type->fields[0]->args[0]->name;
+                $inputType            = $type->fields[0]->args[0]->type->ofType->name;
+                break;
+            }
+        }
+
+        return [
+            $mutation => [
+                $initialMutationField => [
+                    'linksTo'  => '.',
+                    'type'     => Item::class,
+                    'children' => $this->getMutationConfig($jsonSchema, $inputType),
+                ],
+            ],
+        ];
+    }
+
+    private function getTypeFromField($field)
+    {
+        $isCollection = false;
+        $type         = $field->type;
+
+        while ($type->kind !== self::SCALAR && $type->kind !== self::INPUT_OBJECT) {
+            if ($type->kind === self::LIST) {
+                $isCollection = true;
+            }
+            $type = $type->ofType;
+        }
+
+        if ($type->kind === self::SCALAR) {
+            return [
+                'type'         => $type->kind,
+                'isCollection' => $isCollection,
+            ];
+        }
+
+        return [
+            'type'         => $type->name,
+            'isCollection' => $isCollection,
+        ];
+    }
+
+    private function getMutationConfig(stdClass $jsonSchema, $inputType, $parentLinksTo = ''): array
+    {
+        $children = [];
+        foreach ($jsonSchema->data->__schema->types as $type) {
+            if ($type->name === $inputType) {
+                foreach ($type->inputFields as $inputField) {
+                    [
+                        'type'         => $type,
+                        'isCollection' => $isCollection,
+                    ] = $this->getTypeFromField($inputField);
+
+                    if ($type === self::SCALAR) {
+                        $children[$inputField->name] = [
+                            'type' => MutationTypeConfig::SCALAR_DATA_TYPE,
+                        ];
+                        continue;
+                    }
+
+                    $linksTo                     = "{$parentLinksTo}.{$inputField->name}";
+                    $children[$inputField->name] = [
+                        'linksTo'  => $linksTo,
+                        'type'     => $isCollection ? Collection::class : Item::class,
+                        'children' => $this->getMutationConfig($jsonSchema, $type, $linksTo),
+                    ];
+                }
+                break;
+            }
+        }
+
+        return $children;
+    }
+}

--- a/src/Console/Mutation/GetIntrospection.php
+++ b/src/Console/Mutation/GetIntrospection.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Softonic\GraphQL\Console\Mutation;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GetIntrospection extends Command
+{
+    protected static $defaultName = 'mutation:introspection';
+
+    protected function configure()
+    {
+        $this->setDescription('Returns a instrospection query.')
+            ->setHelp('Returns the introspection query needed to execute in your GraphQL server in order ' .
+                'to generate the needed file to generate the config.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln(<<<'GQL'
+query IntrospectionQuery {
+  __schema {
+    mutationType { name }
+    types {
+      ...FullType
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+  }
+  inputFields {
+    ...InputValue
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+GQL
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a CLI for GraphQL Client.

The CLI contains two commands:

- mutation:introspection to get a isntrospection query to be executed in your server
- mutation:generate-config to generate the mutation config needed by the library based on the output of the introspection query.

