### PR TITLE
Explicit nullable type

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -28,7 +28,7 @@ class Client
      * @throws \UnexpectedValueException When response body is not a valid json
      * @throws \RuntimeException         When there are transfer errors
      */
-    public function query(string $query, array $variables = null): Response
+    public function query(string $query, ?array $variables = null): Response
     {
         return $this->executeQuery($query, $variables);
     }

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -8,7 +8,7 @@ class ResponseBuilder
 {
     private $dataObjectBuilder;
 
-    public function __construct(DataObjectBuilder $dataObjectBuilder = null)
+    public function __construct(?DataObjectBuilder $dataObjectBuilder = null)
     {
         $this->dataObjectBuilder = $dataObjectBuilder;
     }


### PR DESCRIPTION
Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead.